### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>Code Louisville</title>
     <link rel="stylesheet" href="assets/fonts/devicon/devicon.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Merriweather+Sans:700,300">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro%7CMerriweather+Sans:700,300">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="assets/css/codelouisville.css">
     <link rel="icon" href="assets/img/favicon.png">


### PR DESCRIPTION
replaced the | (pipe) in the Google fonts link with it's UTF-8 character %7C to clear up validation error.
